### PR TITLE
[FIX] SecurityConfig 수정 (JwtAuthenticationFilter 테스트용)

### DIFF
--- a/src/main/java/com/newstoss/global/config/SecurityConfig.java
+++ b/src/main/java/com/newstoss/global/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import com.newstoss.global.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
@@ -30,8 +29,10 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/**").permitAll() // 로그인, 회원가입은 인증 제외
-//                        .requestMatchers("/api/auth/login", "/api/auth/register").permitAll() // 로그인, 회원가입은 인증 제외
+                        .requestMatchers("/api/news/v2/**").permitAll()
+                        .requestMatchers("/api/newsLogs/**").permitAll()
+//                        .requestMatchers("/**").permitAll() // 로그인, 회원가입은 인증 제외
+                        .requestMatchers("/api/auth/login", "/api/auth/register").permitAll() // 로그인, 회원가입은 인증 제외
                         .anyRequest().authenticated() // 나머지는 인증 필요
                 )
                 .exceptionHandling(ex -> ex


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
close 

## 📝작업 내용

 SecurityConfig에서 일부 API만 허용해서 로그인을 한 뒤에도 특정 페이지에 접속할 때 401 에러가 발생하는지 확인하고자 함.  JwtAuthenticationFilter가 쿠키 추출, 토큰 검증, 회원 로드 등에서 실패하여 SecurityContextHolder에 유효한 Authentication 객체를 설정하는지 확인하고자 함

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
