### PR TITLE
[FIX] 뉴스 컨트롤러에서 직접 SecurityContextHolder 가져오기

### DIFF
--- a/src/main/java/com/newstoss/news/adapter/in/web/news/controller/NewsControllerV2.java
+++ b/src/main/java/com/newstoss/news/adapter/in/web/news/controller/NewsControllerV2.java
@@ -11,11 +11,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @Tag(name = "뉴스 API V2", description = "뉴스 관련 API V2")
@@ -34,10 +34,12 @@ public class NewsControllerV2{
 //    }
     @Operation(summary = "뉴스 상세 조회", description = "특정 뉴스 ID에 해당하는 뉴스 상세 정보를 조회합니다.")
     @GetMapping("/detail")
-    public ResponseEntity<SuccessResponse<Object>> newsdetail(@RequestParam String newsId, @AuthenticationPrincipal Member member){
-        log.info("컨트롤러에서 받은 member: {}", member);
-        UUID memberId = (member != null) ? member.getMemberId() : null;
-        NewsDTOv2 detailNews = newsServiceV2.getDetailNews(newsId, memberId);
+    public ResponseEntity<SuccessResponse<Object>> newsdetail(@RequestParam String newsId){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Object principal = authentication.getPrincipal();
+        log.info("Controller에서 받은 principal: {}", principal);
+        Member member = (principal instanceof Member) ? (Member) principal : null;
+        NewsDTOv2 detailNews = newsServiceV2.getDetailNews(newsId, member.getMemberId());
         return ResponseEntity.ok(new SuccessResponse<>(true,"뉴스 상세 조회 성공", detailNews));
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
close 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

SecurityContextHolder에서 직접 Authentication 객체를 가져와 Principal을 사용해보기

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
